### PR TITLE
Improve renderer focus and add docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Agent Instructions
+
+To modify this repository's Scratch project:
+1. Unzip `Project.sb3` into a temporary directory using `unzip`. The contents include `project.json` and media files.
+2. Use a tool such as `jq` or `python -m json.tool` to pretty-print `project.json` so the JSON is spread across multiple lines (not a single line).
+3. When editing `project.json`, focus solely on the sprite named `renderer`. You can ignore code for any other sprites.
+4. Make any code fixes or additions to `project.json` as required by the task.
+5. Rezip the modified files back into `Project.sb3` preserving the original filenames.
+6. Summarize each change in the `changes` file with a short explanation of what was changed and why.

--- a/PROJECT_OBJECTS.md
+++ b/PROJECT_OBJECTS.md
@@ -1,0 +1,103 @@
+# Project Variables and Custom Blocks
+
+This document lists variables defined in the project and the custom blocks implemented in the `renderer` sprite.
+
+## Stage Variables
+- CamSpeed
+- ModelTris
+- ModelVerts
+- RotSpeed
+- a
+- b
+- c
+- ch
+- cmd
+- current
+- cx
+- cy
+- cz
+- d
+- draggingVert
+- far
+- floor y
+- gridSize
+- i
+- idxtext
+- isDragging
+- j
+- k
+- line
+- max
+- maxLine
+- min
+- minLine
+- mode
+- mouseStartX
+- mouseStartY
+- moveDX
+- moveDY
+- moveDZ
+- my variable
+- near
+- objlines
+- p
+- pitch
+- px
+- px2
+- pxA
+- pxB
+- py
+- py2
+- pyA
+- pyB
+- roll
+- sb2b
+- screenCenterX
+- screenCenterY
+- selectedVert
+- sx
+- sxa
+- sxb
+- sy
+- sya
+- syb
+- sz
+- sz2
+- sz2a
+- sz2b
+- sza
+- szb
+- szb2
+- t
+- tokens
+- tri
+- vx
+- vxa
+- vxb
+- vy
+- vya
+- vyb
+- vz
+- vza
+- vzb
+- x
+- xa
+- xb
+- ya
+- yaw
+- yb
+- z
+- za
+- zb
+
+## Custom Blocks in `renderer`
+- Draw3dLine (advanced) %s %s %s %s %s %s
+- DrawFloorGrid
+- DrawModelEdges
+- DrawTriangle
+- ImportOBJ
+- MoveCamera
+- Render3D
+- SetCamera %s %s %s %s
+- TransformVertices
+- first slash %s

--- a/changes
+++ b/changes
@@ -1,1 +1,2 @@
 
+Updated AGENTS instructions to focus on the renderer sprite. Added PROJECT_OBJECTS.md documenting stage variables and renderer custom blocks.


### PR DESCRIPTION
## Summary
- clarify AGENTS instructions to only edit the `renderer` sprite
- document all stage variables and `renderer` custom blocks in PROJECT_OBJECTS.md

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871c906bf5c8332b982499b08630981